### PR TITLE
Server-side validation fails when using a Uri datatype.  

### DIFF
--- a/DataAnnotationsExtensions/UrlAttribute.cs
+++ b/DataAnnotationsExtensions/UrlAttribute.cs
@@ -55,7 +55,8 @@ namespace DataAnnotationsExtensions
                 return true;
             }
 
-            string valueAsString = value as string;
+            var valueAsString = ( value.GetType() == typeof( Uri ) ) ? value.ToString() : value as string;
+            
             return valueAsString != null &&
                    new Regex(_regex, RegexOptions.Compiled | RegexOptions.IgnoreCase).Match(valueAsString).Length > 0;
         }


### PR DESCRIPTION
You can't cast a Uri datatype to string using a reference conversion.  This commit fixes the issue by checking if the object is a Uri and using ToString() before the RegEx match.
