### PR TITLE
FileExtensions and HttpPostedFileBase

### DIFF
--- a/DataAnnotationsExtensions.Tests/DataAnnotationsExtensions.Tests.csproj
+++ b/DataAnnotationsExtensions.Tests/DataAnnotationsExtensions.Tests.csproj
@@ -64,6 +64,7 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Controllers\HomeControllerTest.cs" />
+    <Compile Include="Doubles\HttpPostedFileBaseStub.cs" />
     <Compile Include="ValidationAttributes\YearAttributeTests.cs" />
     <Compile Include="ValidationAttributes\CreditCardAttributeTests.cs" />
     <Compile Include="ValidationAttributes\CuitAttributeTests.cs" />

--- a/DataAnnotationsExtensions.Tests/Doubles/HttpPostedFileBaseStub.cs
+++ b/DataAnnotationsExtensions.Tests/Doubles/HttpPostedFileBaseStub.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace DataAnnotationsExtensions.Tests.Doubles
+{
+    public class HttpPostedFileBaseStub : HttpPostedFileBase
+    {
+        public HttpPostedFileBaseStub(string fileName)
+        {
+            _fileName = fileName;
+        }
+
+        private string _fileName { set; get; }
+        public override string FileName { 
+            get
+            {
+                return _fileName;
+            } 
+        }
+    }
+}

--- a/DataAnnotationsExtensions.Tests/ValidationAttributes/FileExtensionsAttributeTests.cs
+++ b/DataAnnotationsExtensions.Tests/ValidationAttributes/FileExtensionsAttributeTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.Globalization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using DataAnnotationsExtensions.Tests.Doubles;
 
 namespace DataAnnotationsExtensions.Tests.ValidationAttributes
 {
@@ -23,11 +24,13 @@ namespace DataAnnotationsExtensions.Tests.ValidationAttributes
             Assert.IsTrue(attribute.IsValid("foo.jpeg"));
             Assert.IsTrue(attribute.IsValid("foo.jpg"));
             Assert.IsTrue(attribute.IsValid("foo.gif"));
+            Assert.IsTrue(attribute.IsValid(new HttpPostedFileBaseStub("foo.gif")));
             Assert.IsTrue(attribute.IsValid(@"C:\Foo\bar.png"));
             Assert.IsFalse(attribute.IsValid("foo"));
             Assert.IsFalse(attribute.IsValid("foo.doc"));
             Assert.IsFalse(attribute.IsValid("foo.txt"));
             Assert.IsFalse(attribute.IsValid("foo.png.txt"));
+            Assert.IsFalse(attribute.IsValid(new HttpPostedFileBaseStub("foo.png.txt")));
         }
 
         [TestMethod]
@@ -40,10 +43,12 @@ namespace DataAnnotationsExtensions.Tests.ValidationAttributes
             Assert.IsTrue(attribute.IsValid("foo.doc"));
             Assert.IsTrue(attribute.IsValid("foo.docx"));
             Assert.IsTrue(attribute.IsValid("foo.rtf"));
+            Assert.IsTrue(attribute.IsValid(new HttpPostedFileBaseStub("foo.rtf")));
             Assert.IsTrue(attribute.IsValid(@"C:\Foo\bar.pdf"));
             Assert.IsFalse(attribute.IsValid("foo"));
             Assert.IsFalse(attribute.IsValid("foo.png"));
             Assert.IsFalse(attribute.IsValid("foo.jpeg"));
+            Assert.IsFalse(attribute.IsValid(new HttpPostedFileBaseStub("foo.jpeg")));
             Assert.IsFalse(attribute.IsValid("foo.doc.txt"));
         }
 

--- a/DataAnnotationsExtensions/DataAnnotationsExtensions.csproj
+++ b/DataAnnotationsExtensions/DataAnnotationsExtensions.csproj
@@ -40,6 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/DataAnnotationsExtensions/FileExtensionsAttribute.cs
+++ b/DataAnnotationsExtensions/FileExtensionsAttribute.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using DataAnnotationsExtensions.Resources;
+using System.Web;
 
 namespace DataAnnotationsExtensions
 {
@@ -37,8 +38,17 @@ namespace DataAnnotationsExtensions
             {
                 return true;
             }
-            
-            string valueAsString = value as string;
+
+            string valueAsString;
+            if (value != null && value is HttpPostedFileBase)
+            {
+                valueAsString = (value as HttpPostedFileBase).FileName;
+            }
+            else
+            {
+                valueAsString = value as string;
+            }
+
             if (valueAsString != null)
             {
                 return ValidateExtension(valueAsString);


### PR DESCRIPTION
Fixes #36.

I have moved HttpPostedFileBaseStub into its own folder called Doubles and done some testing by quickly throwing together a test app and everything works as expected.
