### PR TITLE
Explicitly set target platform to build

### DIFF
--- a/Build.cmd
+++ b/Build.cmd
@@ -7,4 +7,4 @@ if "%buildnum%" == "" (
     set buildnum=1.0.2
 )
 
-%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild Build\Build.proj /p:Configuration="%config%" /p:BUILD_NUMBER="%buildnum%"
+%WINDIR%\Microsoft.NET\Framework\v4.0.30319\msbuild Build\Build.proj /p:Configuration="%config%" /p:Platform="Any CPU" /p:BUILD_NUMBER="%buildnum%"


### PR DESCRIPTION
Build fails on systems when a System environment variable with name 'Platform' is defined.

See: http://blog.deltacode.be/2012/04/18/msbuild-failure-on-platform-hpd/
